### PR TITLE
Added 'dlt' (data load tool) to Data Integration section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Companies:
   - [Cube](https://cube.dev)
   - [Fivetran](https://www.fivetran.com)
   - [Airbyte](https://airbyte.io)
+  - [dlt](https://dlthub.com/)
 - Modern OLAP
   - [Apache Druid](https://druid.apache.org/)
   - [ClickHouse](https://clickhouse.com/)


### PR DESCRIPTION
dlt is an open-source library that you can add to your Python scripts to load data from various and often messy data sources into well-structured, live datasets.

dlt has automated maintenance, run where python runs, and is user friendly.