### PR TITLE
Added 2 whitepapers: On XTable and MapReduce

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Data Engineering Whitepapers:
 - [Spark: Cluster Computing with Working Sets](https://dl.acm.org/doi/10.5555/1863103.1863113)
 - [The Google File System](https://research.google/pubs/the-google-file-system/)
 - [Building a Universal Data Lakehouse](https://www.onehouse.ai/whitepaper/onehouse-universal-data-lakehouse-whitepaper)
+- [XTable in Action: Seamless Interoperability in Data Lakes](https://arxiv.org/abs/2401.09621)
+- [MapReduce: Simplified Data Processing on Large Clusters](https://research.google/pubs/mapreduce-simplified-data-processing-on-large-clusters/)
 
 Great YouTube Channels:
 


### PR DESCRIPTION
Added 2 Whitepapers to the Data Engineering Whitepapers section:
1. Xtable in Action  - This whitepaper explains Xtable - the architecture, components, etc. An abstraction to interchange between different table formats. 
2. MapReduce - Google's whitepaper that they came out with back in 2004. 