### PR TITLE
fix: removed obsolete version attribute from docker-compose file

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/docker-compose.yml
+++ b/bootcamp/materials/1-dimensional-data-modeling/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.10.6"
 services:
   postgres:
     image: postgres:14

--- a/bootcamp/materials/1-dimensional-data-modeling/scripts/init-db.sh
+++ b/bootcamp/materials/1-dimensional-data-modeling/scripts/init-db.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 set -e
 
-# Import the data dump
-psql \
-    -v ON_ERROR_STOP=1 \
-    --username $POSTGRES_USER \
-    --dbname $POSTGRES_DB \
-    < /docker-entrypoint-initdb.d/data.dump
-
+# Restore the dump file using pg_restore
+pg_restore \
+    -v \
+    --no-owner \
+    --no-privileges \
+    -U $POSTGRES_USER \
+    -d $POSTGRES_DB \
+    /docker-entrypoint-initdb.d/data.dump
 
 # Check if the path is a directory using the -d flag and
 #  there are SQL files in the directory using the -f command


### PR DESCRIPTION
# Fix 
Removed obsolete version attribute from docker compose file, since it was returning a warning.

# Why?
To prevent any future issues and make the process clearer.

## Screenshot
<img width="1394" alt="image" src="https://github.com/user-attachments/assets/fb2c75ea-436b-4e9d-87ef-e242f910615e">
