### PR TITLE
Postgres not loading data.dump with docker

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/docker-compose.yml
+++ b/bootcamp/materials/1-dimensional-data-modeling/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.10.6"
 services:
   postgres:
     image: postgres:14

--- a/bootcamp/materials/1-dimensional-data-modeling/scripts/init-db.sh
+++ b/bootcamp/materials/1-dimensional-data-modeling/scripts/init-db.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 set -e
 
-# Import the data dump
-psql \
-    -v ON_ERROR_STOP=1 \
-    --username $POSTGRES_USER \
-    --dbname $POSTGRES_DB \
-    < /docker-entrypoint-initdb.d/data.dump
-
+# Restore the dump file using pg_restore
+pg_restore \
+    -v \
+    --no-owner \
+    --no-privileges \
+    -U $POSTGRES_USER \
+    -d $POSTGRES_DB \
+    /docker-entrypoint-initdb.d/data.dump
 
 # Check if the path is a directory using the -d flag and
 #  there are SQL files in the directory using the -f command


### PR DESCRIPTION
# Changes
Changed init-db.sh to use directly pg restore instead of psql to load data dump

## Why?
Postgres was not loading data.dump with the psql command, using docker.
changed to pgrestore instead.

Also, removed the "version" attribute from docker compose file, which was returning a warning.

## Screenshot
![image](https://github.com/user-attachments/assets/69c5d99b-4a5e-40ea-8cb2-b7391978ab5f)

