### PR TITLE
fix scorer_class def on players.sql

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql
@@ -18,7 +18,7 @@
      draft_round TEXT,
      draft_number TEXT,
      seasons season_stats[],
-     scoring_class scorer_class,
+     scorer_class scoring_class,
      is_active BOOLEAN,
      current_season INTEGER,
      PRIMARY KEY (player_name, current_season)


### PR DESCRIPTION
scorer_class type was switched with scoring_class type, this change fix it by writing the field name and its type in the rights order. Please consider it.