### PR TITLE
Fix broken link for Interesting Data Gigs

### DIFF
--- a/newsletters.md
+++ b/newsletters.md
@@ -20,7 +20,7 @@
 - [All Hands on Data](https://allhandsondata.substack.com/)
 - [Modern Data 101](https://moderndata101.substack.com/)
 - [SELECT Insights](https://newsletter.ssp.sh/)
-- [Interesting Data Gigs](https://newsletter.interestinggigs.com)
+- [Interesting Data Gigs](https://www.interestinggigs.com/)
 - [Ju Data Engineering Weekly](https://juhache.substack.com/)
 - [From An Engineer Sight](https://fromanengineersight.substack.com/)
 - [Data Engineering Community](https://dataengineeringcommunity.substack.com/)


### PR DESCRIPTION
The original link (https://newsletter.interestinggigs.com) was not working and showed a DNS error.  Updated the link to the working URL (https://www.interestinggigs.com).