### PR TITLE
fix (day2): update `scorer_class` to `scoring_class`

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/sql/load_players_table_day2.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/sql/load_players_table_day2.sql
@@ -63,7 +63,7 @@ SELECT
         WHEN (seasons[CARDINALITY(seasons)]::season_stats).pts > 15 THEN 'good'
         WHEN (seasons[CARDINALITY(seasons)]::season_stats).pts > 10 THEN 'average'
         ELSE 'bad'
-    END::scorer_class AS scorer_class,
+    END::scoring_class AS scoring_class,
     w.season - (seasons[CARDINALITY(seasons)]::season_stats).season as years_since_last_active,
     w.season,
     (seasons[CARDINALITY(seasons)]::season_stats).season = season AS is_active


### PR DESCRIPTION
In the lab video the column is named `scoring_class` :

```sql
CREATE TABLE players (
    player_name TEXT,
    height TEXT,
    college TEXT,
    country TEXT,
	draft_year TEXT,
    draft_round TEXT,
    draft_number TEXT,
    season_stats season_stats[],
    scoring_class scoring_class,
    years_since_last_season INTEGER,
    current_season INTEGER,
    is_active BOOLEAN,
    PRIMARY KEY(player_name, current_season)
);
```