### PR TITLE
fix HOST_PORT in docker compose file

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/docker-compose.yml
+++ b/bootcamp/materials/1-dimensional-data-modeling/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     ports:
-      - "${CONTAINER_PORT}:5432"
+      - "${HOST_PORT}:5432"
     volumes:
       - ./:/bootcamp/
       - ./data.dump:/docker-entrypoint-initdb.d/data.dump


### PR DESCRIPTION
Replaced `"${CONTAINER_PORT}:5432"` with `"${HOST_PORT}:5432"` for consistency.
Fixes #131