### PR TITLE
Add years_since_last_active column to Match the insert in day 2 lab

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql
@@ -19,6 +19,7 @@
      draft_number TEXT,
      seasons season_stats[],
      scorer_class scoring_class,
+     years_since_last_active INTEGER,
      is_active BOOLEAN,
      current_season INTEGER,
      PRIMARY KEY (player_name, current_season)


### PR DESCRIPTION
## Changes
- Add years_since_last_active column to Match the [insert query ](https://github.com//DataExpert-io/data-engineer-handbook/blob/b5004cce9533968f6175d1b68248528ed42cd31a/bootcamp/materials/1-dimensional-data-modeling/sql/load_players_table_day2.sql )in day 2 lab