### PR TITLE
SCD schema change to remove "current_year" column

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/incremental_scd_query.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/incremental_scd_query.sql
@@ -9,8 +9,7 @@ CREATE TYPE scd_type AS (
 
 WITH last_season_scd AS (
     SELECT * FROM players_scd
-    WHERE current_season = 2021
-    AND end_season = 2021
+    WHERE end_season = 2021
 ),
      historical_scd AS (
         SELECT
@@ -20,8 +19,7 @@ WITH last_season_scd AS (
                start_season,
                end_season
         FROM players_scd
-        WHERE current_season = 2021
-        AND end_season < 2021
+        WHERE end_season < 2021
      ),
      this_season_data AS (
          SELECT * FROM players

--- a/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players_scd_table.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players_scd_table.sql
@@ -4,7 +4,6 @@ create table players_scd_table
 	scoring_class scoring_class,
 	is_active boolean,
 	start_season integer,
-	end_date integer,
-	current_season INTEGER
+	end_date integer
 );
 

--- a/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/scd_generation_query.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/scd_generation_query.sql
@@ -27,7 +27,7 @@ WITH streak_started AS (
          SELECT
             player_name,
             scoring_class,
-            is_active
+            is_active,
             streak_identifier,
             MIN(current_season) AS start_date,
             MAX(current_season) AS end_date

--- a/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/scd_generation_query.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/scd_generation_query.sql
@@ -6,7 +6,12 @@ WITH streak_started AS (
                (PARTITION BY player_name ORDER BY current_season) <> scoring_class
                OR LAG(scoring_class, 1) OVER
                (PARTITION BY player_name ORDER BY current_season) IS NULL
-               AS did_change
+               AS scoring_class_did_change,
+           LAG(is_active, 1) OVER
+               (PARTITION BY player_name ORDER BY current_season) <> is_active
+               OR LAG(is_active, 1) OVER
+               (PARTITION BY player_name ORDER BY current_season) IS NULL
+               AS is_active_did_change
     FROM players
 ),
      streak_identified AS (
@@ -14,7 +19,7 @@ WITH streak_started AS (
             player_name,
                 scoring_class,
                 current_season,
-            SUM(CASE WHEN did_change THEN 1 ELSE 0 END)
+            SUM(CASE WHEN (scoring_class_did_change or is_active_did_change) THEN 1 ELSE 0 END)
                 OVER (PARTITION BY player_name ORDER BY current_season) as streak_identifier
          FROM streak_started
      ),
@@ -22,12 +27,13 @@ WITH streak_started AS (
          SELECT
             player_name,
             scoring_class,
+            is_active
             streak_identifier,
             MIN(current_season) AS start_date,
             MAX(current_season) AS end_date
          FROM streak_identified
-         GROUP BY 1,2,3
+         GROUP BY 1,2,3,4
      )
 
-     SELECT player_name, scoring_class, start_date, end_date
+     SELECT player_name, scoring_class, is_active, start_date, end_date
      FROM aggregated


### PR DESCRIPTION
In the full load of SCD, we don't have "current_year" and this column is been used in the incremental build. This is confusing to 
many, I believe. So, 3 changes:
1. Modified the SCD schema removing "current_year"
2. Added "is_active" dimension in the full load SCD
3. Removed "current_year" condition with historical_scd temp table in the incremental load SCD