### PR TITLE
fix: change column name to season_stats

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql
@@ -17,7 +17,7 @@
      draft_year TEXT,
      draft_round TEXT,
      draft_number TEXT,
-     seasons season_stats[],
+     season_stats season_stats[],
      scorer_class scoring_class,
      years_since_last_active INTEGER,
      is_active BOOLEAN,


### PR DESCRIPTION
I saw the video lab and when i copy this code i got this error that season_stats doesn't exists on yesterday and that's because this sql has a different name for the column.

Here the moment on video: [youtube](https://youtu.be/dWj8VeBEQCc?t=407)