### PR TITLE
Fix: docker compose command in Makefile doesn't need a dash

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/Makefile
+++ b/bootcamp/materials/1-dimensional-data-modeling/Makefile
@@ -7,11 +7,11 @@ up:
 		cp example.env .env; \
         exit 1; \
 	fi
-	docker-compose up -d;
+	docker compose up -d;
 
 .PHONY: down
 down:
-	docker-compose down -v
+	docker compose down -v
 	@if [[ "$(docker ps -q -f name=${DOCKER_CONTAINER})" ]]; then \
 		echo "Terminating running container..."; \
 		docker rm ${DOCKER_CONTAINER}; \
@@ -19,9 +19,9 @@ down:
 
 .PHONY: restart
 restart:
-	docker-compose down -v; \
+	docker compose down -v; \
 	sleep 5; \
-	docker-compose up -d;
+	docker compose up -d;
 
 .PHONY: logs
 logs:


### PR DESCRIPTION
When composing the Makefile with Docker, `make up` throws an error `docker-compose: command not found`. That is because `docker-compose` doesn't exist but `docker compose` does. Removing the dash fixed all the errors.