### PR TITLE
fix: rename scorer_class for consistency with lectures

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql
@@ -18,7 +18,7 @@
      draft_round TEXT,
      draft_number TEXT,
      seasons season_stats[],
-     scorer_class scoring_class,
+     scoring_class scoring_class,
      years_since_last_active INTEGER,
      is_active BOOLEAN,
      current_season INTEGER,

--- a/bootcamp/materials/1-dimensional-data-modeling/sql/load_players_table_day2.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/sql/load_players_table_day2.sql
@@ -63,7 +63,7 @@ SELECT
         WHEN (seasons[CARDINALITY(seasons)]::season_stats).pts > 15 THEN 'good'
         WHEN (seasons[CARDINALITY(seasons)]::season_stats).pts > 10 THEN 'average'
         ELSE 'bad'
-    END::scorer_class AS scorer_class,
+    END::scoring_class AS scoring_class,
     w.season - (seasons[CARDINALITY(seasons)]::season_stats).season as years_since_last_active,
     w.season,
     (seasons[CARDINALITY(seasons)]::season_stats).season = season AS is_active


### PR DESCRIPTION
In [Dimensional Data Modeling Day 2 Lab](https://www.youtube.com/watch?v=nyu-8Si21ec) It's always referred as _scoring_class_, running [load_players_table_day2.sql](../blob/main/bootcamp/materials/1-dimensional-data-modeling/sql/load_players_table_day2.sql) results in error due to bad casting (in day 1 the TYPE created is named _scoring_class_  as shown [here](../blob/main/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql))