### PR TITLE
Fix bootcamp/materials/1-dimensional-data-modeling/lecture-lab/pipeline_query.sql

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/pipeline_query.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/lecture-lab/pipeline_query.sql
@@ -1,7 +1,6 @@
 WITH last_season AS (
     SELECT * FROM players
     WHERE current_season = 1997
-
 ), this_season AS (
      SELECT * FROM player_seasons
     WHERE season = 1998
@@ -34,9 +33,12 @@ SELECT
                     ELSE 'bad' END)::scoring_class
              ELSE ls.scoring_class
          END as scoring_class,
-         ts.season IS NOT NULL as is_active,
-         1998 AS current_season
-
+		CASE 
+			WHEN ts.season IS NOT NULL THEN 0 
+			ELSE ls.years_since_last_active + 1
+		END AS years_since_last_active,
+        ts.season IS NOT NULL AS is_active,
+		COALESCE(ts.season, ls.current_season + 1) AS current_season
     FROM last_season ls
     FULL OUTER JOIN this_season ts
     ON ls.player_name = ts.player_name


### PR DESCRIPTION
This PR aims to fix the `pipeline_query.sql` in accordance with the lab work done by Zach.

It adds the missing column, `years_since_last_active`, which was preventing the query from running. Additionally, it automates the `current_season`, allowing you to only modify the current season in the CTEs to populate the table.