### PR TITLE
fix: add ports to docker compose to expose spark ui

### DIFF
--- a/bootcamp/materials/3-spark-fundamentals/docker-compose.yaml
+++ b/bootcamp/materials/3-spark-fundamentals/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       - 8080:8080
       - 10000:10000
       - 10001:10001
+      - 4040-4042:4040-4042
   rest:
     image: tabulario/iceberg-rest
     container_name: iceberg-rest


### PR DESCRIPTION
Fixes #225
Usually access `localhost:4041`, sometimes is on `localhost:4042`, is not straightforward, Spark UI link is not directing you to `localhost`.
Is a good starting point to access the UI, could be improved after feedback.