### PR TITLE
Fix Issue #244: remove quotes from env file

### DIFF
--- a/bootcamp/materials/4-apache-flink-training/example.env
+++ b/bootcamp/materials/4-apache-flink-training/example.env
@@ -11,8 +11,8 @@ PYTHON_VERSION=3.7.9
 
 
 
-POSTGRES_URL="jdbc:postgresql://host.docker.internal:5432/postgres"
-JDBC_BASE_URL="jdbc:postgresql://host.docker.internal:5432"
+POSTGRES_URL=jdbc:postgresql://host.docker.internal:5432/postgres
+JDBC_BASE_URL=jdbc:postgresql://host.docker.internal:5432
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=postgres


### PR DESCRIPTION
#244 

This fix is made due to an IllegalStateException when running command `make job` 
