### PR TITLE
fix typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Top must-join communities for ML:
   - [dlt](https://dlthub.com/)
   - [Sling](https://slingdata.io/)
   - [Meltano](https://meltano.com/)
- - Semantic Layers
+- Semantic Layers
   - [Cube](https://cube.dev)
   - [dbt Semantic Layer](https://www.getdbt.com/product/semantic-layer) 
 - Modern OLAP


### PR DESCRIPTION
at the moment, the indentation is broken for Semantic layers