### PR TITLE
Fix: Inconsistent table names in Flink Kafka Sinks.

### DIFF
--- a/bootcamp/materials/4-apache-flink-training/src/job/start_job.py
+++ b/bootcamp/materials/4-apache-flink-training/src/job/start_job.py
@@ -5,7 +5,7 @@ import json
 import requests
 from pyflink.table import EnvironmentSettings, DataTypes, TableEnvironment, StreamTableEnvironment
 
-def create_processed_events_sink_kafka(t_env):
+    table_name = "raw_events_kafka"
     table_name = "process_events_kafka"
     kafka_key = os.environ.get("KAFKA_WEB_TRAFFIC_KEY", "")
     kafka_secret = os.environ.get("KAFKA_WEB_TRAFFIC_SECRET", "")


### PR DESCRIPTION
The `start_job.py` file creates a Kafka sink named `process_events_kafka`, while `aggregation_job.py` creates a Kafka source with the same name `process_events_kafka`. This can cause confusion and potentially lead to the aggregation job reading from the sink it is writing to, which would be incorrect.

Fix:
--- a/bootcamp\materials\4-apache-flink-training\src\job\start_job.py
+++ b/bootcamp\materials\4-apache-flink-training\src\job\start_job.py
@@ -5,7 +5,7 @@
 from pyflink.table import EnvironmentSettings, DataTypes, TableEnvironment, StreamTableEnvironment
 
 def create_processed_events_sink_kafka(t_env):
-    table_name = "process_events_kafka"
+    table_name = "raw_events_kafka"
     kafka_key = os.environ.get("KAFKA_WEB_TRAFFIC_KEY", "")
     kafka_secret = os.environ.get("KAFKA_WEB_TRAFFIC_SECRET", "")
     sasl_config = f'org.apache.kafka.common.security.plain.PlainLoginModule required username="{kafka_key}" password="{kafka_secret}";'