### PR TITLE
Fix : lab Spark - docker-compose update with the correct mc command entrypoint (for newer versions of mc)

### DIFF
--- a/bootcamp/materials/3-spark-fundamentals/docker-compose.yaml
+++ b/bootcamp/materials/3-spark-fundamentals/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
       - AWS_REGION=us-east-1
     entrypoint: >
       /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;


### PR DESCRIPTION
**Problem :** mc config host add minio http://minio:9000/ admin password" => it throws an <ERROR> config is not a recognized command. (in the container logs)

**Solution** : Using alias instead of config in the entrypoint: until (/usr/bin/mc alias set minio http://minio:9000/ admin password) do echo '...waiting...' && sleep 1; done;