### PR TITLE
fix : lab Spark - Update failing test `test_monthly_site_hits` due to an empty array

### DIFF
--- a/bootcamp/materials/3-spark-fundamentals/src/jobs/monthly_user_site_hits_job.py
+++ b/bootcamp/materials/3-spark-fundamentals/src/jobs/monthly_user_site_hits_job.py
@@ -7,10 +7,10 @@ from pyspark.sql import SparkSession
 def do_monthly_user_site_hits_transformation(spark, dataframe, ds):
     query = f"""
     SELECT
-           month_start,
-           SUM(COALESCE(hit_array[0], 0)) as num_hits_first_day,
-           SUM(COALESCE(hit_array[1], 0)) AS num_hits_second_day,
-           SUM(COALESCE(hit_array[2], 0)) as num_hits_third_day
+          month_start,
+          SUM(COALESCE(get(hit_array, 0), 0)) AS num_hits_first_day,
+          SUM(COALESCE(get(hit_array, 1), 0)) AS num_hits_second_day,
+          SUM(COALESCE(get(hit_array, 2), 0)) AS num_hits_third_day
     FROM monthly_user_site_hits
     WHERE date_partition = '{ds}'
     GROUP BY month_start


### PR DESCRIPTION
In week 3, the Spark test `test_monthly_site_hits` fails due to an empty array.
This fix uses the `get()` to tolerate accessing element at invalid index and return NULL instead


**Before**
```

spark = <pyspark.sql.session.SparkSession object at 0x111154440>

    def test_monthly_site_hits(spark):
        ds = "2023-03-01"
        new_month_start = "2023-04-01"
        input_data = [
            # Make sure basic case is handled gracefully
            MonthlySiteHit(
                month_start=ds,
                hit_array=[0, 1, 3],
                date_partition=ds
            ),
            MonthlySiteHit(
                month_start=ds,
                hit_array=[1, 2, 3],
                date_partition=ds
            ),
            #  Make sure empty array is handled gracefully
            MonthlySiteHit(
                month_start=new_month_start,
                hit_array=[],
                date_partition=ds
            ),
            # Make sure other partitions get filtered
            MonthlySiteHit(
                month_start=new_month_start,
                hit_array=[],
                date_partition=""
            )
        ]

        source_df = spark.createDataFrame(input_data)
        actual_df = do_monthly_user_site_hits_transformation(spark, source_df, ds)

        expected_values = [
            MonthlySiteHitsAgg(
                month_start=ds,
                num_hits_first_day=1,
                num_hits_second_day=3,
                num_hits_third_day=6
            ),
            MonthlySiteHitsAgg(
                month_start=new_month_start,
                num_hits_first_day=0,
                num_hits_second_day=0,
                num_hits_third_day=0
            )
        ]
        expected_df = spark.createDataFrame(expected_values)
>       assert_df_equality(actual_df, expected_df)

src/tests/test_monthly_user_site_hits.py:57:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.venv/lib/python3.13/site-packages/chispa/dataframe_comparer.py:66: in assert_df_equality
    df1.collect(),
    ^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/pyspark/sql/classic/dataframe.py:443: in collect
    sock_info = self._jdf.collectToPython()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/py4j/java_gateway.py:1362: in __call__
    return_value = get_return_value(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

a = ('xro74', <py4j.clientserver.JavaClient object at 0x1053de3c0>, 'o51', 'collectToPython'), kw = {}, Py4JJavaError = <class 'py4j.protocol.Py4JJavaError'>
converted = ArrayIndexOutOfBoundsException()

    def deco(*a: Any, **kw: Any) -> Any:
        from py4j.protocol import Py4JJavaError

        try:
            return f(*a, **kw)
        except Py4JJavaError as e:
            converted = convert_exception(e.java_exception)
            if not isinstance(converted, UnknownException):
                # Hide where the exception came from that shows a non-Pythonic
                # JVM exception message.
>               raise converted from None
E               pyspark.errors.exceptions.captured.ArrayIndexOutOfBoundsException: [INVALID_ARRAY_INDEX] The index 0 is out of bounds. The array has 0 elements. Use the SQL function `get()` to tolerate accessing element at invalid index and return NULL instead. SQLSTATE: 22003
E               == SQL (line 4, position 25) ==
E                          SUM(COALESCE(hit_array[0], 0)) as num_hits_first_day,
E                                       ^^^^^^^^^^^^

.venv/lib/python3.13/site-packages/pyspark/errors/exceptions/captured.py:288: ArrayIndexOutOfBoundsException
---------------------------------------------------------------------------- Captured log call ----------------------------------------------------------------------------
ERROR    SQLQueryContextLogger:logger.py:289 [INVALID_ARRAY_INDEX] The index 0 is out of bounds. The array has 0 elements. Use the SQL function `get()` to tolerate accessing element at invalid index and return NULL instead. SQLSTATE: 22003
Traceback (most recent call last):
  File "/Users/maxime/github/data-engineer-handbook/bootcamp/materials/3-spark-fundamentals/.venv/lib/python3.13/site-packages/pyspark/errors/exceptions/captured.py", line 282, in deco
    return f(*a, **kw)
  File "/Users/maxime/github/data-engineer-handbook/bootcamp/materials/3-spark-fundamentals/.venv/lib/python3.13/site-packages/py4j/protocol.py", line 327, in get_return_value
    raise Py4JJavaError(
        "An error occurred while calling {0}{1}{2}.\n".
        format(target_id, ".", name), value)
py4j.protocol.Py4JJavaError: An error occurred while calling o51.collectToPython.
: org.apache.spark.SparkArrayIndexOutOfBoundsException: [INVALID_ARRAY_INDEX] The index 0 is out of bounds. The array has 0 elements. Use the SQL function `get()` to tolerate accessing element at invalid index and return NULL instead. SQLSTATE: 22003
== SQL (line 4, position 25) ==
           SUM(COALESCE(hit_array[0], 0)) as num_hits_first_day,
                        ^^^^^^^^^^^^

	at org.apache.spark.sql.errors.QueryExecutionErrors$.invalidArrayIndexError(QueryExecutionErrors.scala:233)
	at org.apache.spark.sql.errors.QueryExecutionErrors.invalidArrayIndexError(QueryExecutionErrors.scala)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.hashAgg_doAggregate_sum_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.hashAgg_doConsume_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.hashAgg_doAggregateWithKeys_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext(WholeStageCodegenEvaluatorFactory.scala:50)
	at scala.collection.Iterator$$anon$9.hasNext(Iterator.scala:583)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:143)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:57)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:111)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:54)
	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:171)
	at org.apache.spark.scheduler.Task.run(Task.scala:147)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$5(Executor.scala:647)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:80)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:77)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:650)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
========================================================================= short test summary info =========================================================================
FAILED src/tests/test_monthly_user_site_hits.py::test_monthly_site_hits - pyspark.errors.exceptions.captured.ArrayIndexOutOfBoundsException: [INVALID_ARRAY_INDEX] The index 0 is out of bounds. The array has 0 elements. Use the SQL function ..
```

**After**
```
=========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.13.2, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/maxime/github/data-engineer-handbook/bootcamp/materials/3-spark-fundamentals
collected 3 items

src/tests/test_monthly_user_site_hits.py .                                                                                                                          [ 33%]
src/tests/test_player_scd.py .                                                                                                                                      [ 66%]
src/tests/test_team_vertex_job.py .                                                                                                                                 [100%]

============================================================================ 3 passed in 5.04s ============================================================================
```