### PR TITLE
docs: add Java 11 requirement note to Spark setup

### DIFF
--- a/bootcamp/materials/3-spark-fundamentals/README.md
+++ b/bootcamp/materials/3-spark-fundamentals/README.md
@@ -2,6 +2,8 @@
 
 ## Unit Testing PySpark Course Getting Started
 
+### Spark requires Java 11 to function correctly. Java 17+ may cause test failures due to security manager restrictions.
+
 You need to install the required dependencies in `requirements.txt`
 
 Running `pip install -r requirements.txt` will install them.


### PR DESCRIPTION
### Description:
Running python -m pytest fails with UnsupportedOperationException: getSubject on systems with Java 17 or higher. This is due to PySpark incompatibility with Java 17+.

> Steps to Reproduce:
> 
> Check Java Version (if 17 or higher)
> 
> Run pip install -r requirements.txt
> 
> Run python -m pytest
> 
> Observe the Py4JJavaError from Spark context initialization.

### Suggested Fix:
**Please update the README.md in 3-spark-fundamentals to mention that Java 11 is required to run PySpark tests successfully.**