### PR TITLE
Add DuckLake on Data Lake platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Top must-join communities for ML:
   - [Onehouse](https://www.onehouse.ai)
   - [Delta Lake](https://delta.io/)
   - [Ilum](https://ilum.cloud/)
+  - [DuckLake](https://ducklake.select/)
 - Data Warehouse
   - [Snowflake](https://www.snowflake.com/en/)
   - [Firebolt](https://www.firebolt.io/)


### PR DESCRIPTION
Add DuckLake on Data Lake platform.

From the [official site](https://ducklake.select/):
"DuckLake delivers advanced data lake features without traditional lakehouse complexity by using Parquet files and your SQL database"