### PR TITLE
Add Apache Iceberg and REST Catalogs (Polaris & Lakekeeper) to Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Top must-join communities for ML:
   - [Delta Lake](https://delta.io/)
   - [Ilum](https://ilum.cloud/)
   - [DuckLake](https://ducklake.select/)
+  - [Apache Iceberg](https://iceberg.apache.org/)
+  - [Apache Polaris](https://polaris.apache.org/)
+  - [Lakekeeper](https://lakekeeper.io/)
 - Data Warehouse
   - [Snowflake](https://www.snowflake.com/en/)
   - [Firebolt](https://www.firebolt.io/)


### PR DESCRIPTION
This PR updates the project README to include references to:

[Apache Iceberg](https://iceberg.apache.org/)

[Apache Polaris](https://polaris.apache.org/)

[Lakekeeper](https://lakekeeper.io/)

These additions highlight key technologies in the modern data engineering ecosystem, particularly in the context of open table formats and REST-based catalog implementations.

Why:

Apache Iceberg is an increasingly adopted open table format for large-scale data lake and lakehouse architectures. Polaris and Lakekeeper are notable REST Catalog implementations that enable modular and interoperable catalog management. Including them provides readers with valuable context and resources for exploring modern data infrastructure patterns.