### PR TITLE
Update load_players_table_day2.sql to match players schema

### DIFF
--- a/bootcamp/materials/1-dimensional-data-modeling/sql/load_players_table_day2.sql
+++ b/bootcamp/materials/1-dimensional-data-modeling/sql/load_players_table_day2.sql
@@ -65,8 +65,8 @@ SELECT
         ELSE 'bad'
     END::scoring_class AS scoring_class,
     w.season - (seasons[CARDINALITY(seasons)]::season_stats).season as years_since_last_active,
-    w.season,
-    (seasons[CARDINALITY(seasons)]::season_stats).season = season AS is_active
+    (seasons[CARDINALITY(seasons)]::season_stats).season = season AS is_active,
+    w.season
 FROM windowed w
 JOIN static s
     ON w.player_name = s.player_name;


### PR DESCRIPTION
[player_seasons.sql](https://github.com/DataExpert-io/data-engineer-handbook/blob/main/bootcamp/materials/1-dimensional-data-modeling/sql/player_seasons.sql)  defines the schema as having `season` as the last column. This change updates the seed script for the day 2 lecture to be correct. Otherwise, the seed script will not work due to a type mismatch.