### PR TITLE
update mc command and remove deprecated docker-compose version

### DIFF
--- a/bootcamp/materials/3-spark-fundamentals/docker-compose.yaml
+++ b/bootcamp/materials/3-spark-fundamentals/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   spark-iceberg:
     image: tabulario/spark-iceberg
@@ -66,7 +64,7 @@ services:
       - AWS_REGION=us-east-1
     entrypoint: >
       /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;


### PR DESCRIPTION
- Replace deprecated 'mc config host add' with 'mc alias set' for MinIO client
- Remove 'version: "3"' as it is ignored in Docker Compose v2+