### PR TITLE
Fix Windows port conflict: change MinIO console from 9001 to 9101

### DIFF
--- a/intermediate-bootcamp/materials/3-spark-fundamentals/docker-compose.yaml
+++ b/intermediate-bootcamp/materials/3-spark-fundamentals/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
         aliases:
           - warehouse.minio
     ports:
-      - 9001:9001
+      - 9101:9001 #changed from 9001:9001 to 9101:9001 to avoid conflicts with reserved ports on Windows
       - 9000:9000
     command: ["server", "/data", "--console-address", ":9001"]
   mc:


### PR DESCRIPTION
Windows reserves port 9001 (PID 4), and Docker cannot bind to it. I changed it to 9101 on the host without breaking the container. It worked properly for me.