### PR TITLE
Updated Readme to change directory to the correct path

### DIFF
--- a/intermediate-bootcamp/materials/1-dimensional-data-modeling/README.md
+++ b/intermediate-bootcamp/materials/1-dimensional-data-modeling/README.md
@@ -31,7 +31,7 @@ Clone the course files onto your machine:
 
 ```bash
 git clone git@github.com:DataExpert-io/data-engineer-handbook.git
-cd data-engineer-handbook/bootcamp/materials/1-dimensional-data-modeling
+cd data-engineer-handbook/intermediate-bootcamp/materials/1-dimensional-data-modeling
 ```
 
 > 🔐 Need SSH set up first? Use [GitHub’s SSH guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)


### PR DESCRIPTION
The handbook still uses the old path, `bootcamp/materials` in the `1-dimensional-data-modeling` README. I updated that to `intermediate-bootcamp/materials/1-dimensional-data-modeling`