### PR TITLE
fix season_stats type definition and players table load bug

### DIFF
--- a/intermediate-bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql
+++ b/intermediate-bootcamp/materials/1-dimensional-data-modeling/lecture-lab/players.sql
@@ -1,5 +1,6 @@
  CREATE TYPE season_stats AS (
-                         season Integer,
+                         season INTEGER,
+                         gp REAL,
                          pts REAL,
                          ast REAL,
                          reb REAL,

--- a/intermediate-bootcamp/materials/1-dimensional-data-modeling/sql/load_players_table_day2.sql
+++ b/intermediate-bootcamp/materials/1-dimensional-data-modeling/sql/load_players_table_day2.sql
@@ -26,7 +26,8 @@ WITH years AS (
                             ps.gp,
                             ps.pts,
                             ps.reb,
-                            ps.ast
+                            ps.ast,
+                            ps.weight
                         )::season_stats
                 END)
             OVER (PARTITION BY pas.player_name ORDER BY COALESCE(pas.season, ps.season)),


### PR DESCRIPTION
update the players table insert query & the season_stats TYPE definition to fix issue where

1. games played "gp" attribute was being loaded into the points table. This caused most if not all players to be tagged as having a "bad" scoring class
2. weight was not being loaded into the players table