### PR TITLE
Add "Data with Baraa" YouTube channel to Data Engineering creators list

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Here's the mostly comprehensive list of data engineering creators:
 | Name                        | YouTube Channel                                                                                         | Follower Count |
 |----------------------------|---------------------------------------------------------------------------------------------------------|---------------:|
 | ByteByteGo                 | [ByteByteGo](https://www.youtube.com/c/ByteByteGo)                                             | 1,000,000+     |
+| Data with Baraa            | [Data with Baraa](https://www.youtube.com/@DataWithBaraa)                                       | 195,000+     |
 | Zach Wilson                | [Data with Zach](https://www.youtube.com/@eczachly_)                                          | 150,000+       |
 | Shashank Mishra            | [E-learning Bridge](https://www.youtube.com/@shashank_mishra)                                   | 100,000+       |
 | Seattle Data Guy           | [Seattle Data Guy](https://www.youtube.com/c/SeattleDataGuy)                                  | 100,000+       |


### PR DESCRIPTION
Adds the Data with Baraa YouTube channel row to the README list of data-engineering creators.

- Channel: Data with Baraa
- URL: https://www.youtube.com/@DataWithBaraa
- Display name: Baraa Khatib Salkini (channel)
- Follower count noted: ~195,000+

This change matches the existing table style and includes channel link and follower estimate. Please update follower count if an exact number is preferred.

Contributed by: VinsmokeSomya (via fork/PR)