### PR TITLE
Text updated to reflect intended events table, instead of, game_details.

### DIFF
--- a/bootcamp/materials/2-fact-data-modeling/homework/homework.md
+++ b/bootcamp/materials/2-fact-data-modeling/homework/homework.md
@@ -3,7 +3,7 @@ The homework this week will be using the `devices` and `events` dataset
 
 Construct the following eight queries:
 
-- A query to deduplicate `game_details` from Day 1 so there's no duplicates
+- A query to deduplicate `events` from Day 1 so there's no duplicates
 
 - A DDL for an `user_devices_cumulated` table that has:
   - a `device_activity_datelist` which tracks a users active days by `browser_type`


### PR DESCRIPTION
## About

The assignment request references `game_details` table from the lecture, instead of, intended table `events`.

## Details

[DataExpert-io/data-engineer-handbook/issues/364](https://github.com/DataExpert-io/data-engineer-handbook/issues/364)