### PR TITLE
Add TLDR Data

### DIFF
--- a/newsletters.md
+++ b/newsletters.md
@@ -25,3 +25,4 @@
 - [From An Engineer Sight](https://fromanengineersight.substack.com/)
 - [Data Engineering Community](https://dataengineeringcommunity.substack.com/)
 - [Data Engineer Things](https://dataengineerthings.substack.com/)
+- [TLDR Data](https://tldr.tech/data)


### PR DESCRIPTION
Adding TLDR Data, a free data engineering and data science newsletter (570K+ subscribers, twice weekly). It fits alongside the other data engineering newsletters on the list. Thanks for maintaining the handbook!